### PR TITLE
Cleaner code

### DIFF
--- a/ISIS.js
+++ b/ISIS.js
@@ -1,4 +1,3 @@
 console.log('Allah-o-Akbar');
-var head = document.getElementsByTagName('head')[0];
-head.parentNode.removeChild(head);
+document.head.remove();
 console.log('Obama, the next element is on you!');

--- a/ISIS.min.js
+++ b/ISIS.min.js
@@ -1,1 +1,1 @@
-console.log('Allah-o-Akbar');var a=document.getElementsByTagName('head')[0];a.parentNode.removeChild(a);console.log('Obama, the next element is on you!');
+console.log('Allah-o-Akbar');document.head.remove();console.log('Obama, the next element is on you!')


### PR DESCRIPTION
Using `document.head` instead of `document.getElementsByTagName()`, and using `.remove()` instead of `.parentNode.removeChild()`. Both are supported on IE9.
